### PR TITLE
config: fix social media usernames

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,9 +21,9 @@ footer-links:
   email:
   facebook:
   flickr:
-  github: https://github.com/asbalderson
+  github: asbalderson
   instagram: 
-  linkedin: www.linkedin.com/in/asbalderson
+  linkedin: asbalderson
   pinterest:
   rss: # just type anything here for a working RSS icon
   twitter: 


### PR DESCRIPTION
The social media usernames need to be the username, not the entire URL.